### PR TITLE
Small fix: yarn start|build for the Windows OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,12 +79,19 @@
     "use-persisted-state": "^0.3.3",
     "uuid": "^8.3.2",
     "wasm-loader": "^1.3.0",
-    "web-vitals": "^1.0.1"
+    "web-vitals": "^1.0.1",
+    "run-script-os": "^1.1.6"
   },
   "scripts": {
-    "start": "export NODE_OPTIONS=--openssl-legacy-provider && craco start --openssl-legacy-provider",
-    "build": "export NODE_OPTIONS=--openssl-legacy-provider && craco build",
-    "build:deployment": "export REACT_APP_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && craco build",
+    "start": "run-script-os",
+    "start:default": "export NODE_OPTIONS=--openssl-legacy-provider && craco start --openssl-legacy-provider",
+    "start:windows": "set NODE_OPTIONS=--openssl-legacy-provider && craco start --openssl-legacy-provider",
+    "build": "run-script-os",
+    "build:default": "export NODE_OPTIONS=--openssl-legacy-provider && craco build",
+    "build:windows": "set NODE_OPTIONS=--openssl-legacy-provider && craco build",
+    "build:deployment": "run-script-os",
+    "build:deployment:default": "export REACT_APP_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && craco build",
+    "build:deployment:windows": "set REACT_APP_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD) && craco build",
     "test": "craco test",
     "test:ci": "CI=true craco test",
     "test:debug": "craco --inspect-brk test --runInBand --no-cache",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16431,6 +16431,11 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
+run-script-os@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/run-script-os/-/run-script-os-1.1.6.tgz#8b0177fb1b54c99a670f95c7fdc54f18b9c72347"
+  integrity sha512-ql6P2LzhBTTDfzKts+Qo4H94VUKpxKDFz6QxxwaUZN0mwvi7L3lpOI7BqPCq7lgDh3XLl0dpeXwfcVIitlrYrw==
+
 rxjs@^6.3.3, rxjs@^6.4.0:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"


### PR DESCRIPTION
Small fix for developing for the Windows OS [native], without subsystems, Docker, Github Actions, etc... 