### PR TITLE
docs(readme.md): fix storybook invocation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ yarn install
 Start Storybook component development environment.
 
 ```
-yarn storybook
+yarn storybook:start
 ```
 
 Storybook can be opened at [:6006](http://localhost:6006)


### PR DESCRIPTION
## Description
Fix storybook invocation in `README.md` (also adding a newline to the end of the file).

## Related Issue
Should I open an issue for this?

## Motivation and Context
Makes it harder for new contributors if the `README.md` has wrong instructions.

## Checklist:
- [x] I have updated the documentation if necessary.
- [ ] I have added tests to cover my changes, regression test if fixing an issue.
- [ ] This is a breaking change.
