### PR TITLE
fix: Fix overflow when long wallet name

### DIFF
--- a/src/components/Wallet/AccountSelector/AccountItem/AccountItem.scss
+++ b/src/components/Wallet/AccountSelector/AccountItem/AccountItem.scss
@@ -92,6 +92,7 @@
       display: flex;
       gap: 8px;
       align-items: center;
+      width: 100%;
 
       &__name {
         font-size: 16px;

--- a/src/components/Wallet/AccountSelector/AccountItem/AccountItem.scss
+++ b/src/components/Wallet/AccountSelector/AccountItem/AccountItem.scss
@@ -82,7 +82,9 @@
   &__heading {
     width: 100%;
     display: flex;
-    gap: 16px;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 5px;
     font-weight: 500;
     justify-content: space-between;
 

--- a/src/pages/WalletPage/containers/WalletPage/ActiveAccount/ActiveAccount.scss
+++ b/src/pages/WalletPage/containers/WalletPage/ActiveAccount/ActiveAccount.scss
@@ -81,6 +81,7 @@
     align-items: center;
     justify-content: center;
     border: none;
+    cursor: pointer;
 
     &:hover {
       background: rgba(76, 243, 168, 0.3);


### PR DESCRIPTION
Before:
<img width="649" alt="Screenshot 2022-07-19 at 13 35 12" src="https://user-images.githubusercontent.com/55109377/179740849-ff810894-1f4e-4a8e-956c-87b880223253.png">

After:
<img width="565" alt="Screenshot 2022-07-19 at 13 34 23" src="https://user-images.githubusercontent.com/55109377/179740714-2863af6e-2fea-457d-84d8-d7c68f97f077.png">

